### PR TITLE
Azurerm.Profile

### DIFF
--- a/tools/AzureRM/AzureRM.psd1
+++ b/tools/AzureRM/AzureRM.psd1
@@ -88,6 +88,7 @@ RequiredModules = @(@{ModuleName = 'AzureRM.Profile'; RequiredVersion = '5.0.1';
                @{ModuleName = 'AzureRM.NotificationHubs'; RequiredVersion = '5.0.0'; }, 
                @{ModuleName = 'AzureRM.OperationalInsights'; RequiredVersion = '5.0.0'; }, 
                @{ModuleName = 'AzureRM.PowerBIEmbedded'; RequiredVersion = '4.1.5'; }, 
+	       @{ModuleName = 'AzureRM.profile'; RequiredVersion = '5.0.1'; }, 
                @{ModuleName = 'AzureRM.RecoveryServices'; RequiredVersion = '4.1.3'; }, 
                @{ModuleName = 'AzureRM.RecoveryServices.Backup'; RequiredVersion = '4.1.3'; }, 
                @{ModuleName = 'AzureRM.RecoveryServices.SiteRecovery'; RequiredVersion = '0.2.5'; }, 


### PR DESCRIPTION
Adding Azurerm.profile to list of required modules, which is missing.  This creates an issue where, after the azurerm module has been installed on a fresh machine (did not have the module installed prior), the azurerm.profile module is not being imported into the powershell session with the other azurerm modules, and the user has to either a) import the module manually, or b) restart the powershell console.  By adding the azurerm.profile module to the list of required modules (why was it removed in the first place?), this should fix this issue.

<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

<!-- Please add a brief description of the changes made in this PR -->

## Checklist

- [x] I have read the [_Submitting Changes_](https://github.com/Azure/azure-powershell/blob/preview/CONTRIBUTING.md#submitting-changes) section of [`CONTRIBUTING.md`](https://github.com/Azure/azure-powershell/blob/preview/CONTRIBUTING.md)
- [x] The title of the PR is clear and informative
- [x] The appropriate [change log has been updated](https://github.com/Azure/azure-powershell/blob/preview/CONTRIBUTING.md#updating-the-change-log)
- [x] The PR does not introduce [breaking changes](https://github.com/Azure/azure-powershell/blob/preview/documentation/breaking-changes/breaking-changes-definition.md)
- [x] If applicable, the changes made in the PR have proper test coverage
- [ ] For public API changes to cmdlets:
    - [ ] the changes have gone through a [cmdlet design review](https://github.com/Azure/azure-powershell-cmdlet-review-pr)
    - [ ] the cmdlet markdown files were [generated using the `platyPS` module](https://github.com/Azure/azure-powershell/blob/preview/documentation/development-docs/help-generation.md)
